### PR TITLE
Fix out of memory access in parser

### DIFF
--- a/tools/xml2cpp-codegen/xml.cpp
+++ b/tools/xml2cpp-codegen/xml.cpp
@@ -292,12 +292,12 @@ void Document::Expat::character_data_handler(void* data, const XML_Char* chars, 
         nod = &(nod->children.back());
     }
 
-    int x = 0, y = len - 1;
+    int offset = 0, count = len;
 
-    while (isspace(chars[y]) && y > 0) --y;
-    while (isspace(chars[x]) && x < y) ++x;
+    while (count > 0 && isspace(chars[count - 1])) --count;
+    while (offset < count && isspace(chars[offset])) { ++offset; --count; }
 
-    nod->cdata = std::string(chars, x, y + 1);
+    nod->cdata = std::string{chars + offset, static_cast<std::string::size_type>(count)};
 }
 
 void Document::Expat::end_element_handler(void* data, const XML_Char* /*name*/)


### PR DESCRIPTION
when the xml2cpp codegen is compiled with -fsanitize=all the program terminates because the wrong std::string constructor is used and it tries to strlen() on a not null terminated string. also the trimming arithmetic was bugged when all characters need to be trimmed.

unhappy asan output before this commit:
https://0x0.st/H1SU.txt